### PR TITLE
fix: prevent redirect loop when re-login after session timeout

### DIFF
--- a/web/app/auth/login/page.tsx
+++ b/web/app/auth/login/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { getOIDCConfig, initiateOIDCLogin, isAuthenticated } from "@/lib/api";
+import { getOIDCConfig, initiateOIDCLogin, isAuthenticated, getCurrentUser, logoutLocal } from "@/lib/api";
 import { Button, Alert } from "@/components/ui";
 
 export default function LoginPage() {
@@ -14,14 +14,21 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Check if already authenticated
-    if (isAuthenticated()) {
-      router.push("/");
-      return;
-    }
+    const checkAuthAndOIDC = async () => {
+      // Check if already authenticated with valid token
+      if (isAuthenticated()) {
+        try {
+          // Validate token is still valid by calling the API
+          await getCurrentUser();
+          router.push("/");
+          return;
+        } catch {
+          // Token is invalid or expired, clear it
+          logoutLocal();
+        }
+      }
 
-    // Check OIDC configuration
-    const checkOIDC = async () => {
+      // Check OIDC configuration
       try {
         const config = await getOIDCConfig();
         setOidcEnabled(config.oidc_enabled);
@@ -34,7 +41,7 @@ export default function LoginPage() {
       }
     };
 
-    checkOIDC();
+    checkAuthAndOIDC();
   }, [router]);
 
   const handleLogin = () => {

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -39,7 +39,9 @@ export default function Header() {
           // Update stored user info if it changed
           storeUserInfo(userData);
         } catch {
-          // Token might be invalid
+          // Token might be invalid or expired - clear cookies
+          // This prevents redirect loops when trying to re-login
+          logoutLocal();
           setIsLoggedIn(false);
           setUser(null);
         }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -58,10 +58,8 @@ export function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  // Redirect to home if accessing auth routes while already authenticated
-  if (isAuthRoute && isAuthenticated) {
-    return NextResponse.redirect(new URL("/", request.url));
-  }
+  // Login page validates token server-side; middleware redirect would cause
+  // redirect loops when JWT expires but cookie persists
 
   // For authenticated requests, forward the auth token in headers for SSR API calls
   if (isAuthenticated) {


### PR DESCRIPTION
## Problem
When a session times out (JWT expires after 24 hours), users cannot re-login because:
1. The auth_token cookie persists (7-day expiry)
2. isAuthenticated() checks cookie existence, not validity
3. Middleware and login page redirect away from /auth/login when cookie exists
4. Users must manually clear cookies to re-authenticate

## Solution
Three targeted fixes to handle expired tokens gracefully:

### 1. Next.js Middleware (proxy.ts)
- Removed aggressive redirect that blocked /auth/login for stale cookies
- Login page now handles validation server-side

### 2. Login Page (login/page.tsx)
- Added token validation with getCurrentUser() API call before redirecting
- Clears invalid cookies via logoutLocal() if token is expired
- Only redirects to home if token is actually valid

### 3. Header Component (Header.tsx)
- Calls logoutLocal() when getCurrentUser() fails
- Prevents redirect loops by clearing invalid cookies immediately

## How It Works
**Before (broken):**
1. Session expires -> cookie persists
2. User clicks "Sign in" -> middleware redirects to home
3. User stuck in loop

**After (fixed):**
1. Session expires -> cookie persists
2. User clicks "Sign in" -> reaches login page
3. Login page validates token -> fails -> clears cookies
4. Login page shows Sign In button
5. User can re-authenticate

## Testing
- Verify login works normally with valid session
- Verify expired sessions allow re-login without manual cookie clearing
- Verify protected routes still redirect to login when not authenticated